### PR TITLE
Break from outer $browserCode loop as well

### DIFF
--- a/MultilanguagePlugin.php
+++ b/MultilanguagePlugin.php
@@ -115,7 +115,7 @@ class MultilanguagePlugin extends Omeka_Plugin_AbstractPlugin
                         for ($i = 0; $i < $lenCodes; $i++) {
                             if (strcmp($bcode, $shortcodes[$i]) == 0) {
                                 $this->locale_code = $codes[$i];
-                                break;
+                                break 2;
                             }
                         }
                     }


### PR DESCRIPTION
An addition to #6. We don't need to keep looping through browser codes once we have set `locale_code`, so break both loops.
